### PR TITLE
feat: add workouts from friend profiles

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -2,10 +2,10 @@ import connectDB from "@/database/db";
 import { NextResponse, NextRequest } from "next/server";
 
 export async function GET(req: Request) {
+  const url = new URL(req.url ? req.url : "invalid");
+  const username = url.searchParams.get("username");
   try {
     const db = connectDB();
-    const url = new URL(req.url ? req.url : "invalid");
-    const username = url.searchParams.get("username");
 
     if (!username) {
       return NextResponse.json({

--- a/src/app/api/workouts/route.ts
+++ b/src/app/api/workouts/route.ts
@@ -67,7 +67,8 @@ export async function POST(req: Request) {
       throw new Error("Failed to connect to the database");
     }
 
-    const { username, duration, difficulty, tags, w_name } = await req.json();
+    const { username, duration, difficulty, tags, w_name, w_id } =
+      await req.json();
 
     if (!username || !duration || !difficulty || !tags || !w_name) {
       throw new Error("Missing required parameters");
@@ -75,9 +76,18 @@ export async function POST(req: Request) {
 
     console.log(username, duration, difficulty, tags, w_name);
 
-    const { data: workout_info, error } = await db
-      .from("workout_info")
-      .insert([{ username, duration, difficulty, tags, w_name }] as any);
+    let workout_info, error;
+    if (w_id) {
+      ({ data: workout_info, error } = await db
+        .from("workout_info")
+        .insert([
+          { w_id, username, duration, difficulty, tags, w_name },
+        ] as any));
+    } else {
+      ({ data: workout_info, error } = await db
+        .from("workout_info")
+        .insert([{ username, duration, difficulty, tags, w_name }] as any));
+    }
 
     if (error) {
       throw error;
@@ -103,6 +113,7 @@ export async function DELETE(req: Request) {
     const db = connectDB();
     const url = new URL(req.url ? req.url : "invalid");
     const w_id = url.searchParams.get("w_id");
+    const username = url.searchParams.get("username");
 
     if (!db) {
       throw new Error("Failed to connect to the database");
@@ -112,19 +123,26 @@ export async function DELETE(req: Request) {
       throw new Error("w_id is missing in the request");
     }
 
+    if (!username) {
+      throw new Error("username is missing in the request");
+    }
+
     const { data: existingWorkouts, error: workout_error } = await db
       .from("workout_info")
       .select("*")
-      .eq("w_id", w_id);
+      .eq("w_id", w_id)
+      .eq("username", username);
 
     if (existingWorkouts && existingWorkouts.length == 0) {
-      throw new Error(`Workout with ID ${w_id} does not exist for user`);
+      throw new Error(
+        `Workout with ID ${w_id} does not exist for user ${username}`,
+      );
     }
 
     const { error: deleteError } = await db
       .from("workout_info")
       .delete()
-      .match({ w_id });
+      .match({ w_id, username });
 
     if (deleteError) {
       throw deleteError;

--- a/src/app/friends/page.tsx
+++ b/src/app/friends/page.tsx
@@ -6,10 +6,12 @@ import { redirect } from "next/navigation";
 import React, { useEffect, useState, useCallback } from "react";
 import { Session } from "next-auth";
 import Unauthorized from "@/components/unauthorized";
+import { useRouter } from "next/navigation";
 
 type Props = { username: string; session: Session };
 
 function Following({ username, session }: Props) {
+  const router = useRouter();
   const getFollowingData = useCallback(async () => {
     try {
       const newFollowing = [];
@@ -79,7 +81,10 @@ function Following({ username, session }: Props) {
                 </Avatar>
               </div>
               <div style={{ marginLeft: "25px" }}>
-                <Button type="submit">
+                <Button
+                  type="submit"
+                  onClick={() => router.push(`/profile/${following.username}`)}
+                >
                   <i style={{ color: "hsl(var(--primary)" }} />
                   <span style={{ color: "hsl(var(--accent))" }}>
                     {following.username}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -136,12 +136,15 @@ export default function Home() {
   async function handleDeleteClick(cardTitle: any) {
     // Extract workout id from card title
     const w_id = cardTitle.split(":")[0].substring(1);
-    const promise = await fetch(`/api/workouts?w_id=${w_id}`, {
-      method: "DELETE",
-      headers: {
-        "Content-Type": "application/json",
+    const promise = await fetch(
+      `/api/workouts?w_id=${w_id}&username=${username}`,
+      {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+        },
       },
-    });
+    );
     // Trigger card reload
     setCardChange(cardChange + 1);
     return promise;


### PR DESCRIPTION
## Developer: Ryan Chan

Closes #58

### Pull Request Summary

- Clicking on following user on `/friends` page redirects to dynamic profile page
- Add friend workouts via profile to own list of workouts
  - Toast components upon submission to indicate either success or failure (for duplicate import)
- Deletion of workout only removes entry associated with the signed in user
  - Any other users who imported that workout will still maintain it on their own profile

### Modifications

- Modify `/api/workouts` `POST` route to allow for optional `w_id` parameter for duplicate entry with different username
- Modify `/api/workouts` `DELETE` route to accommodate extra `username` query parameter and delete only for a specified user
- Modify `/api/profiles` endpoint to fix dynamic server usage

### Testing Considerations

Tested via Postman and in local development environment

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast
<img width="1680" alt="Screenshot 2024-03-12 at 12 31 33 AM" src="https://github.com/ryanchansf/git-fit/assets/91078767/5e55a14b-6375-47e3-874e-c67163298154">
<img width="1680" alt="Screenshot 2024-03-12 at 12 31 54 AM" src="https://github.com/ryanchansf/git-fit/assets/91078767/79d396a3-f118-44f6-98b0-fe34cd86f1f9">
<img width="1680" alt="Screenshot 2024-03-12 at 12 32 20 AM" src="https://github.com/ryanchansf/git-fit/assets/91078767/51dfb264-5de1-499e-bdcb-1b441a39301e">
