### PR TITLE
Fixed Delete Following button

### DIFF
--- a/src/app/following/page.tsx
+++ b/src/app/following/page.tsx
@@ -51,24 +51,31 @@ export default function Following() {
     }
   }, [session, getfollowingData, followingChange]);
 
-  async function handleDeleteClick(remove_user: any) {
-    const message = {
-      following: remove_user,
-    };
-    const promise = await fetch(
-      `/api/following?username=${encodeURIComponent(username || "")}`,
-      {
-        method: "DELETE",
-        headers: {
-          "Content-Type": "application/json",
+  const handleDeleteClick = async (remove_user: any) => {
+    try {
+      const message = {
+        following: remove_user,
+      };
+      const response = await fetch(
+        `/api/following?username=${encodeURIComponent(username || "")}`,
+        {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(message),
         },
-        body: JSON.stringify(message),
-      },
-    );
-    //  console.log("made it back from api call");
-    setfollowingChange(followingChange + 1);
-    return promise;
-  }
+      );
+
+      if (!response.ok) {
+        throw new Error("Failed to delete following");
+      }
+
+      setfollowingChange(followingChange + 1);
+    } catch (error) {
+      console.error("Error deleting following:", error);
+    }
+  };
 
   return (
     <div className="flex flex-col gap-5">
@@ -98,10 +105,13 @@ export default function Following() {
                   </AvatarFallback>
                 </Avatar>
               </div>
+
               <div style={{ marginLeft: "25px" }}>
                 <Button
-                  type="submit"
-                  onClick={() => router.push(`/profile/${following.username}`)}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    router.push(`/profile/${following.username}`);
+                  }}
                 >
                   <i style={{ color: "hsl(var(--primary)" }} />
                   <span style={{ color: "hsl(var(--accent))" }}>
@@ -110,11 +120,15 @@ export default function Following() {
                 </Button>
               </div>
               <div style={{ marginLeft: "25px" }}>
-                <Button className="bg-accent" size="icon">
+                <Button
+                  type="button" // Change type to "button"
+                  className="bg-accent"
+                  size="icon"
+                  onClick={() => handleDeleteClick(following.username)}
+                >
                   <i
                     className="fa-solid fa-trash"
                     style={{ color: "hsl(var(--primary))" }}
-                    onClick={() => handleDeleteClick(following.username)}
                   />
                 </Button>
               </div>

--- a/src/app/profile/[slug]/page.tsx
+++ b/src/app/profile/[slug]/page.tsx
@@ -229,18 +229,14 @@ export default function FriendPage({ params }: { params: { slug: string } }) {
                 <h1 className="font-bold text-4xl">{workoutsCount}</h1>
                 <p className="text-lg">Workouts</p>
               </div>
-              <Link href="/friends">
-                <div className="flex flex-col items-center">
-                  <h1 className="font-bold text-4xl">{followersCount}</h1>
-                  <p className="text-lg">Followers</p>
-                </div>
-              </Link>
-              <Link href="/friends">
-                <div className="flex flex-col items-center">
-                  <h1 className="font-bold text-4xl">{followingCount}</h1>
-                  <p className="text-lg">Following</p>
-                </div>
-              </Link>
+              <div className="flex flex-col items-center">
+                <h1 className="font-bold text-4xl">{followersCount}</h1>
+                <p className="text-lg">Followers</p>
+              </div>
+              <div className="flex flex-col items-center">
+                <h1 className="font-bold text-4xl">{followingCount}</h1>
+                <p className="text-lg">Following</p>
+              </div>
             </div>
           </Card>
           <Card className="flex flex-col border-none items-center justify-center gap-3 py-5 px-10">


### PR DESCRIPTION
## Developer: Hallie Christopherson

### Pull Request Summary
- when the usernames on the friends page became clickable, the delete buttons no longer worked, fixed that
- when viewing someone else's profile, their followers/following buttons were clickable but would take you to your own friends page which is didn't align with the button's functionality
- to fix made them not clickable as we do not currently want users to be able to see who each other follows
